### PR TITLE
GetOne(): Support Insert/Update/Delete query builders

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -93,8 +93,17 @@ func (q *Querier) GetAll(ctx context.Context, query Sqlizer, dest interface{}) e
 	return wrapErr(pgxscan.ScanAll(dest, rows))
 }
 
-func (q *Querier) GetOne(ctx context.Context, query sq.SelectBuilder, dest interface{}) error {
-	rows, err := q.QueryRows(ctx, query.Limit(1))
+func (q *Querier) GetOne(ctx context.Context, query Sqlizer, dest interface{}) error {
+	switch builder := query.(type) {
+	case sq.SelectBuilder:
+		query = builder.Limit(1)
+	case sq.UpdateBuilder:
+		query = builder.Limit(1)
+	case sq.DeleteBuilder:
+		query = builder.Limit(1)
+	}
+
+	rows, err := q.QueryRows(ctx, query)
 	if err != nil {
 		return wrapErr(err)
 	}


### PR DESCRIPTION
Besides `sq.SelectBuilder`, this PR enables `.GetOne()` to scan data from `sq.InsertBuilder`, `sq.UpdateBuilder` and `sq.DeleteBuilder` too.

In other words, you can do this now:

```
func (t *UsersTable) Save(ctx context.Context, user *User) error {
	if user.Id.IsNil() {
		user.Id = uuid.Must(uuid.NewV7())
		q := t.DB.SQL.InsertRecord(user).Suffix(`RETURNING *`)
		return t.DB.Query.GetOne(ctx, q, user)
	}

	q := t.DB.SQL.UpdateRecord(user, squirrel.Eq{"id": user.Id}).Suffix(`RETURNING *`)
	return t.DB.Query.GetOne(ctx, q, user)
}
```