### PR TITLE
Postgres doesn't like LIMIT 1 on UPDATE statements

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -97,8 +97,6 @@ func (q *Querier) GetOne(ctx context.Context, query Sqlizer, dest interface{}) e
 	switch builder := query.(type) {
 	case sq.SelectBuilder:
 		query = builder.Limit(1)
-	case sq.UpdateBuilder:
-		query = builder.Limit(1)
 	case sq.DeleteBuilder:
 		query = builder.Limit(1)
 	}


### PR DESCRIPTION
Fixes `ERROR:  syntax error at or near "LIMIT" at character 421`