### PR TITLE
add basic condition-operator functions

### DIFF
--- a/cond.go
+++ b/cond.go
@@ -30,6 +30,7 @@ func (c condExpr) ToSql() (string, []interface{}, error) {
 	if c.v == nil {
 		return "", nil, nil
 	}
+
 	return "?", []interface{}{c.v}, nil
 }
 
@@ -68,9 +69,11 @@ func (n *condNode) ToSql() (string, []interface{}, error) {
 func compileNodes(nodes []squirrel.Sqlizer) (q string, args []interface{}, err error) {
 	for i, node := range nodes {
 		qn, argsn, err := node.ToSql()
+
 		if err != nil {
 			return "", nil, fmt.Errorf("error compiling node %d: %v", i, err)
 		}
+
 		q += qn
 		args = append(args, argsn...)
 	}
@@ -82,9 +85,11 @@ func compileOperator(leaf interface{}) string {
 	if expr, ok := leaf.(*condExpr); ok {
 		return " " + expr.op
 	}
+
 	if _, ok := leaf.(squirrel.Sqlizer); ok {
 		return ""
 	}
+
 	return " ="
 }
 
@@ -105,9 +110,11 @@ type Cond map[interface{}]interface{}
 
 func (c Cond) ToSql() (string, []interface{}, error) {
 	nodes := []squirrel.Sqlizer{}
+
 	for left, right := range c {
 		nodes = append(nodes, &condNode{left, right})
 	}
+
 	return compileNodes(nodes)
 }
 
@@ -177,6 +184,7 @@ func In(v ...interface{}) squirrel.Sqlizer {
 		if len(v) == 0 {
 			return "IN ()", nil, nil
 		}
+
 		return "IN (?" + strings.Repeat(", ?", len(v)-1) + ")", v, nil
 	})
 }
@@ -187,6 +195,7 @@ func NotIn(v ...interface{}) squirrel.Sqlizer {
 		if len(v) == 0 {
 			return "NOT IN ()", nil, nil
 		}
+
 		return "NOT IN (?" + strings.Repeat(", ?", len(v)-1) + ")", v, nil
 	})
 }
@@ -199,6 +208,7 @@ func AnyOf(v interface{}) squirrel.Sqlizer {
 		if rv.Kind() != reflect.Slice {
 			return "", nil, fmt.Errorf("value must be a slice")
 		}
+
 		if rv.Len() == 0 {
 			return "IN ()", nil, nil
 		}
@@ -217,6 +227,7 @@ func AnyOf(v interface{}) squirrel.Sqlizer {
 func NotAnyOf(v interface{}) squirrel.Sqlizer {
 	return sqlExprFn(func() (string, []interface{}, error) {
 		rv := reflect.ValueOf(v)
+
 		if rv.Kind() != reflect.Slice {
 			return "", nil, fmt.Errorf("value must be a slice")
 		}
@@ -226,6 +237,7 @@ func NotAnyOf(v interface{}) squirrel.Sqlizer {
 		}
 
 		vs := make([]interface{}, rv.Len())
+
 		for i := 0; i < rv.Len(); i++ {
 			vs[i] = rv.Index(i).Interface()
 		}

--- a/cond.go
+++ b/cond.go
@@ -50,12 +50,12 @@ func (n *condNode) ToSql() (string, []interface{}, error) {
 
 	ql, argsl, err := compileLeaf(n.left)
 	if err != nil {
-		return "", nil, fmt.Errorf("error compiling left side: %v", err)
+		return "", nil, fmt.Errorf("error compiling left side: %w", err)
 	}
 
 	rl, argsr, err := compileLeaf(n.right)
 	if err != nil {
-		return "", nil, fmt.Errorf("error compiling right side: %v", err)
+		return "", nil, fmt.Errorf("error compiling right side: %w", err)
 	}
 
 	// always take operator from right side
@@ -71,7 +71,7 @@ func compileNodes(nodes []squirrel.Sqlizer) (q string, args []interface{}, err e
 		qn, argsn, err := node.ToSql()
 
 		if err != nil {
-			return "", nil, fmt.Errorf("error compiling node %d: %v", i, err)
+			return "", nil, fmt.Errorf("error compiling node %d: %w", i, err)
 		}
 
 		q += qn

--- a/cond.go
+++ b/cond.go
@@ -123,6 +123,21 @@ func Eq(v interface{}) squirrel.Sqlizer {
 	return &condExpr{"=", v}
 }
 
+// NotEq represents a not-equal comparison.
+func NotEq(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"<>", v}
+}
+
+// Gt represents a greater-than comparison.
+func Gt(v interface{}) squirrel.Sqlizer {
+	return &condExpr{">", v}
+}
+
+// Gte represents a greater-than-or-equal comparison.
+func Gte(v interface{}) squirrel.Sqlizer {
+	return &condExpr{">=", v}
+}
+
 // Lt represents a less-than comparison.
 func Lt(v interface{}) squirrel.Sqlizer {
 	return &condExpr{"<", v}
@@ -143,24 +158,14 @@ func IsNotNull() squirrel.Sqlizer {
 	return &condExpr{"IS NOT NULL", nil}
 }
 
-// Gt represents a greater-than comparison.
-func Gt(v interface{}) squirrel.Sqlizer {
-	return &condExpr{">", v}
-}
-
-// Gte represents a greater-than-or-equal comparison.
-func Gte(v interface{}) squirrel.Sqlizer {
-	return &condExpr{">=", v}
-}
-
-// NotEq represents a not-equal comparison.
-func NotEq(v interface{}) squirrel.Sqlizer {
-	return &condExpr{"<>", v}
-}
-
 // Like represents a LIKE comparison.
 func Like(v interface{}) squirrel.Sqlizer {
 	return &condExpr{"LIKE", v}
+}
+
+// NotLike represents a NOT LIKE comparison.
+func NotLike(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"NOT LIKE", v}
 }
 
 // ILike represents a ILIKE comparison.
@@ -171,11 +176,6 @@ func ILike(v interface{}) squirrel.Sqlizer {
 // NotILike represents a NOT ILIKE comparison.
 func NotILike(v interface{}) squirrel.Sqlizer {
 	return &condExpr{"NOT ILIKE", v}
-}
-
-// NotLike represents a NOT LIKE comparison.
-func NotLike(v interface{}) squirrel.Sqlizer {
-	return &condExpr{"NOT LIKE", v}
 }
 
 // In represents an IN operator. The value must be variadic.

--- a/cond.go
+++ b/cond.go
@@ -1,0 +1,241 @@
+package pgkit
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+)
+
+type sqlExpr struct {
+	fn func() (string, []interface{}, error)
+}
+
+func (s sqlExpr) ToSql() (string, []interface{}, error) {
+	return s.fn()
+}
+
+func sqlExprFn(fn func() (string, []interface{}, error)) *sqlExpr {
+	return &sqlExpr{fn}
+}
+
+type condExpr struct {
+	op string
+
+	v interface{}
+}
+
+func (c condExpr) ToSql() (string, []interface{}, error) {
+	if c.v == nil {
+		return "", nil, nil
+	}
+	return "?", []interface{}{c.v}, nil
+}
+
+type condNode struct {
+	left  interface{}
+	right interface{}
+}
+
+func (n *condNode) ToSql() (string, []interface{}, error) {
+	_, leftIsString := n.left.(string)
+	_, rightIsExpr := n.right.(squirrel.Sqlizer)
+
+	if leftIsString && !rightIsExpr {
+		// backwards compatibility with old-style conditions
+		return squirrel.Eq{n.left.(string): n.right}.ToSql()
+	}
+
+	ql, argsl, err := compileLeaf(n.left)
+	if err != nil {
+		return "", nil, fmt.Errorf("error compiling left side: %v", err)
+	}
+
+	rl, argsr, err := compileLeaf(n.right)
+	if err != nil {
+		return "", nil, fmt.Errorf("error compiling right side: %v", err)
+	}
+
+	// always take operator from right side
+	if rl == "" {
+		return ql + compileOperator(n.right), argsl, nil
+	}
+
+	return string(ql) + compileOperator(n.right) + " " + string(rl), append(argsl, argsr...), nil
+}
+
+func compileNodes(nodes []squirrel.Sqlizer) (q string, args []interface{}, err error) {
+	for i, node := range nodes {
+		qn, argsn, err := node.ToSql()
+		if err != nil {
+			return "", nil, fmt.Errorf("error compiling node %d: %v", i, err)
+		}
+		q += qn
+		args = append(args, argsn...)
+	}
+
+	return q, args, nil
+}
+
+func compileOperator(leaf interface{}) string {
+	if expr, ok := leaf.(*condExpr); ok {
+		return " " + expr.op
+	}
+	if _, ok := leaf.(squirrel.Sqlizer); ok {
+		return ""
+	}
+	return " ="
+}
+
+func compileLeaf(leaf interface{}) (string, []interface{}, error) {
+	if _, ok := leaf.(string); ok {
+		return leaf.(string), nil, nil
+	}
+
+	if sqlizer, ok := leaf.(squirrel.Sqlizer); ok {
+		return sqlizer.ToSql()
+	}
+
+	return "?", []interface{}{leaf}, nil
+}
+
+// Cond is a map of conditions.
+type Cond map[interface{}]interface{}
+
+func (c Cond) ToSql() (string, []interface{}, error) {
+	nodes := []squirrel.Sqlizer{}
+	for left, right := range c {
+		nodes = append(nodes, &condNode{left, right})
+	}
+	return compileNodes(nodes)
+}
+
+// Eq represents an equality comparison.
+func Eq(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"=", v}
+}
+
+// Lt represents a less-than comparison.
+func Lt(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"<", v}
+}
+
+// Lte represents a less-than-or-equal comparison.
+func Lte(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"<=", v}
+}
+
+// IsNull represents an IS NULL comparison.
+func IsNull() squirrel.Sqlizer {
+	return &condExpr{"IS NULL", nil}
+}
+
+// IsNotNull represents an IS NOT NULL comparison.
+func IsNotNull() squirrel.Sqlizer {
+	return &condExpr{"IS NOT NULL", nil}
+}
+
+// Gt represents a greater-than comparison.
+func Gt(v interface{}) squirrel.Sqlizer {
+	return &condExpr{">", v}
+}
+
+// Gte represents a greater-than-or-equal comparison.
+func Gte(v interface{}) squirrel.Sqlizer {
+	return &condExpr{">=", v}
+}
+
+// NotEq represents a not-equal comparison.
+func NotEq(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"<>", v}
+}
+
+// Like represents a LIKE comparison.
+func Like(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"LIKE", v}
+}
+
+// ILike represents a ILIKE comparison.
+func ILike(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"ILIKE", v}
+}
+
+// NotILike represents a NOT ILIKE comparison.
+func NotILike(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"NOT ILIKE", v}
+}
+
+// NotLike represents a NOT LIKE comparison.
+func NotLike(v interface{}) squirrel.Sqlizer {
+	return &condExpr{"NOT LIKE", v}
+}
+
+// In represents an IN operator. The value must be variadic.
+func In(v ...interface{}) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		if len(v) == 0 {
+			return "IN ()", nil, nil
+		}
+		return "IN (?" + strings.Repeat(", ?", len(v)-1) + ")", v, nil
+	})
+}
+
+// NotIn represents a NOT IN operator. The value must be variadic.
+func NotIn(v ...interface{}) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		if len(v) == 0 {
+			return "NOT IN ()", nil, nil
+		}
+		return "NOT IN (?" + strings.Repeat(", ?", len(v)-1) + ")", v, nil
+	})
+}
+
+// AnyOf represents an IN operator. The value must be a slice.
+func AnyOf(v interface{}) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		rv := reflect.ValueOf(v)
+
+		if rv.Kind() != reflect.Slice {
+			return "", nil, fmt.Errorf("value must be a slice")
+		}
+		if rv.Len() == 0 {
+			return "IN ()", nil, nil
+		}
+
+		vs := make([]interface{}, rv.Len())
+
+		for i := 0; i < rv.Len(); i++ {
+			vs[i] = rv.Index(i).Interface()
+		}
+
+		return "IN (?" + strings.Repeat(", ?", len(vs)-1) + ")", vs, nil
+	})
+}
+
+// NotAnyOf represents a NOT IN operator. The value must be a slice.
+func NotAnyOf(v interface{}) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() != reflect.Slice {
+			return "", nil, fmt.Errorf("value must be a slice")
+		}
+
+		if rv.Len() == 0 {
+			return "NOT IN ()", nil, nil
+		}
+
+		vs := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			vs[i] = rv.Index(i).Interface()
+		}
+
+		return "NOT IN (?" + strings.Repeat(", ?", len(vs)-1) + ")", vs, nil
+	})
+}
+
+func Raw(sql string, args ...interface{}) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		return sql, args, nil
+	})
+}

--- a/db/cond_test.go
+++ b/db/cond_test.go
@@ -1,0 +1,194 @@
+package db_test
+
+import (
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/goware/pgkit/v2/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCond(t *testing.T) {
+
+	t.Run("equal to", func(t *testing.T) {
+		cond := db.Cond{"one": 1}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{1}, args)
+		assert.Equal(t, "one = ?", s)
+	})
+
+	t.Run("equal to (inverted)", func(t *testing.T) {
+		cond := db.Cond{1: "one"}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{1}, args)
+		assert.Equal(t, "? = one", s)
+	})
+
+	t.Run("equal to subquery", func(t *testing.T) {
+		q := sq.Select("id").From("users").Where(db.Cond{"badge": "admin"})
+
+		cond := db.Cond{"id": q}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, "id = (SELECT id FROM users WHERE badge = ?)", s)
+		assert.Equal(t, []interface{}{"admin"}, args)
+	})
+
+	t.Run("less than or equal", func(t *testing.T) {
+		cond := db.Cond{"id": db.Lte(1)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{1}, args)
+		assert.Equal(t, "id <= ?", s)
+	})
+
+	t.Run("single node", func(t *testing.T) {
+		cond := db.Lte(1)
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{1}, args)
+		assert.Equal(t, "?", s)
+	})
+
+	t.Run("IS NULL", func(t *testing.T) {
+		cond := db.Cond{"status": db.IsNull()}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Empty(t, args)
+		assert.Equal(t, "status IS NULL", s)
+	})
+
+	t.Run("IN with slice", func(t *testing.T) {
+		cond := db.Cond{"list": db.In(1, 2, 3)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{1, 2, 3}, args)
+		assert.Equal(t, "list IN (?, ?, ?)", s)
+	})
+
+	t.Run("NOT IN", func(t *testing.T) {
+		cond := db.Cond{"list": db.NotIn("Czech Republic", "Slovakia")}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
+		assert.Equal(t, "list NOT IN (?, ?)", s)
+	})
+
+	t.Run("IN with empty slice", func(t *testing.T) {
+		cond := db.Cond{"list": db.In[any]()}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Empty(t, args)
+		assert.Equal(t, "list IN ()", s)
+	})
+
+	t.Run("NOT IN with empty slice", func(t *testing.T) {
+		cond := db.Cond{"list": db.NotIn[any]()}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Empty(t, args)
+		assert.Equal(t, "list NOT IN ()", s)
+	})
+
+	t.Run("IN with slice of strings", func(t *testing.T) {
+		{
+			cond := db.Cond{"list": db.In[string]("Czech Republic", "Slovakia")}
+			s, args, err := cond.ToSql()
+			require.NoError(t, err)
+
+			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
+			assert.Equal(t, "list IN (?, ?)", s)
+		}
+
+		{
+			cond := db.Cond{"list": db.In[interface{}]("Czech Republic", "Slovakia")}
+			s, args, err := cond.ToSql()
+			require.NoError(t, err)
+
+			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
+			assert.Equal(t, "list IN (?, ?)", s)
+		}
+
+		{
+			list := []string{"Czech Republic", "Slovakia"}
+			cond := db.Cond{"list": db.NotIn[string](list...)}
+			s, args, err := cond.ToSql()
+			require.NoError(t, err)
+
+			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
+			assert.Equal(t, "list NOT IN (?, ?)", s)
+		}
+	})
+
+	t.Run("raw condition", func(t *testing.T) {
+		cond := db.Cond{"salary": db.Raw("> ANY(SELECT salary FROM managers WHERE id < ?)", 23)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{23}, args)
+		assert.Equal(t, "salary > ANY(SELECT salary FROM managers WHERE id < ?)", s)
+	})
+
+	t.Run("LIKE with string value", func(t *testing.T) {
+		cond := db.Cond{"name": db.Like("john")}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"john"}, args)
+		assert.Equal(t, "name LIKE ?", s)
+	})
+
+	t.Run("ANY(list) = 1", func(t *testing.T) {
+		{
+			cond := db.Cond{db.Raw("ANY(list)"): 1}
+			s, args, err := cond.ToSql()
+			require.NoError(t, err)
+
+			assert.Equal(t, []interface{}{1}, args)
+			assert.Equal(t, "ANY(list) = ?", s)
+		}
+
+		{
+			cond := db.Cond{db.Func("ANY", db.Raw("list")): 1}
+			s, args, err := cond.ToSql()
+			require.NoError(t, err)
+
+			assert.Equal(t, []interface{}{1}, args)
+			assert.Equal(t, "ANY (list) = ?", s)
+		}
+	})
+
+	t.Run("ANY(list) <> 1", func(t *testing.T) {
+		cond := db.Cond{db.Raw("ANY(list)"): db.NotEq(1)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{1}, args)
+		assert.Equal(t, "ANY(list) <> ?", s)
+	})
+
+	t.Run("id IN subquery", func(t *testing.T) {
+		q := sq.Select("id").From("users").Where(
+			db.Or{
+				db.Cond{"status": db.Eq("active")},
+				db.Cond{"status": db.Eq("banned")},
+			},
+		)
+
+		cond := db.Cond{"id": db.In(q)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"active", "banned"}, args)
+		assert.Equal(t, "id IN (SELECT id FROM users WHERE (status = ? OR status = ?))", s)
+	})
+}

--- a/pgkit.go
+++ b/pgkit.go
@@ -121,9 +121,3 @@ func wrapErr(err error) error {
 		return fmt.Errorf("pgkit: %w", err)
 	}
 }
-
-type Cond map[string]interface{}
-
-func (c Cond) ToSql() (string, []interface{}, error) {
-	return sq.Eq(c).ToSql()
-}

--- a/tests/pgkit_test.go
+++ b/tests/pgkit_test.go
@@ -14,6 +14,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/goware/pgkit/v2"
+	"github.com/goware/pgkit/v2/db"
 	"github.com/goware/pgkit/v2/dbtype"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
@@ -702,7 +703,7 @@ func TestSugarBatchQuery(t *testing.T) {
 
 	queries := pgkit.Queries{}
 	for _, name := range names {
-		queries.Add(DB.SQL.Select("*").From("accounts").Where(pgkit.Cond{"name": name}))
+		queries.Add(DB.SQL.Select("*").From("accounts").Where(db.Cond{"name": name}))
 	}
 
 	batchResults, batchLen, err := DB.Query.BatchQuery(ctx, queries)
@@ -792,150 +793,4 @@ func hexEncode(b []byte) string {
 	enc := make([]byte, len(b)*2)
 	hex.Encode(enc[0:], b)
 	return string(enc)
-}
-
-func TestCond(t *testing.T) {
-
-	t.Run("equal to", func(t *testing.T) {
-		cond := pgkit.Cond{"one": 1}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "one = ?", s)
-	})
-
-	t.Run("equal to (inverted)", func(t *testing.T) {
-		cond := pgkit.Cond{1: "one"}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "? = one", s)
-	})
-
-	t.Run("less than or equal", func(t *testing.T) {
-		cond := pgkit.Cond{"id": pgkit.Lte(1)}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "id <= ?", s)
-	})
-
-	t.Run("single node", func(t *testing.T) {
-		cond := pgkit.Lte(1)
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "?", s)
-	})
-
-	t.Run("IS NULL", func(t *testing.T) {
-		cond := pgkit.Cond{"status": pgkit.IsNull()}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Empty(t, args)
-		assert.Equal(t, "status IS NULL", s)
-	})
-
-	t.Run("IN with slice", func(t *testing.T) {
-		cond := pgkit.Cond{"list": pgkit.In(1, 2, 3)}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{1, 2, 3}, args)
-		assert.Equal(t, "list IN (?, ?, ?)", s)
-	})
-
-	t.Run("NOT IN", func(t *testing.T) {
-		cond := pgkit.Cond{"list": pgkit.NotIn("Czech Republic", "Slovakia")}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
-		assert.Equal(t, "list NOT IN (?, ?)", s)
-	})
-
-	t.Run("IN with empty slice", func(t *testing.T) {
-		cond := pgkit.Cond{"list": pgkit.In[any]()}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Empty(t, args)
-		assert.Equal(t, "list IN ()", s)
-	})
-
-	t.Run("NOT IN with empty slice", func(t *testing.T) {
-		cond := pgkit.Cond{"list": pgkit.NotIn[any]()}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Empty(t, args)
-		assert.Equal(t, "list NOT IN ()", s)
-	})
-
-	t.Run("IN with slice of strings", func(t *testing.T) {
-		{
-			cond := pgkit.Cond{"list": pgkit.In[string]("Czech Republic", "Slovakia")}
-			s, args, err := cond.ToSql()
-			require.NoError(t, err)
-
-			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
-			assert.Equal(t, "list IN (?, ?)", s)
-		}
-
-		{
-			cond := pgkit.Cond{"list": pgkit.In[interface{}]("Czech Republic", "Slovakia")}
-			s, args, err := cond.ToSql()
-			require.NoError(t, err)
-
-			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
-			assert.Equal(t, "list IN (?, ?)", s)
-		}
-
-		{
-			list := []string{"Czech Republic", "Slovakia"}
-			cond := pgkit.Cond{"list": pgkit.NotIn[string](list...)}
-			s, args, err := cond.ToSql()
-			require.NoError(t, err)
-
-			assert.Equal(t, []interface{}{"Czech Republic", "Slovakia"}, args)
-			assert.Equal(t, "list NOT IN (?, ?)", s)
-		}
-	})
-
-	t.Run("raw condition", func(t *testing.T) {
-		cond := pgkit.Cond{"salary": pgkit.Raw("> ANY(SELECT salary FROM managers WHERE id < ?)", 23)}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{23}, args)
-		assert.Equal(t, "salary > ANY(SELECT salary FROM managers WHERE id < ?)", s)
-	})
-
-	t.Run("LIKE with string value", func(t *testing.T) {
-		cond := pgkit.Cond{"name": pgkit.Like("john")}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{"john"}, args)
-		assert.Equal(t, "name LIKE ?", s)
-	})
-
-	t.Run("ANY(list) = 1", func(t *testing.T) {
-		cond := pgkit.Cond{pgkit.Raw("ANY(list)"): 1}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "ANY(list) = ?", s)
-	})
-
-	t.Run("ANY(list) <> 1", func(t *testing.T) {
-		cond := pgkit.Cond{pgkit.Raw("ANY(list)"): pgkit.NotEq(1)}
-		s, args, err := cond.ToSql()
-		require.NoError(t, err)
-
-		assert.Equal(t, []interface{}{1}, args)
-		assert.Equal(t, "ANY(list) <> ?", s)
-	})
 }


### PR DESCRIPTION
This PR enhaces `pgkit.Cond` with the ability of accepting `interface{}` on both sides. The right side might contain an operator, which, if present, will be used to compile a condition. 