### PR TITLE
Ignore error when new column is added to DB schema (allow backward-compatible migrations)

### DIFF
--- a/querier.go
+++ b/querier.go
@@ -16,6 +16,7 @@ import (
 type Querier struct {
 	pool *pgxpool.Pool
 	tx   pgx.Tx
+	Scan *pgxscan.API
 	SQL  *StatementBuilder
 }
 
@@ -90,7 +91,7 @@ func (q *Querier) GetAll(ctx context.Context, query Sqlizer, dest interface{}) e
 	if err != nil {
 		return wrapErr(err)
 	}
-	return wrapErr(pgxscan.ScanAll(dest, rows))
+	return wrapErr(q.Scan.ScanAll(dest, rows))
 }
 
 func (q *Querier) GetOne(ctx context.Context, query Sqlizer, dest interface{}) error {
@@ -105,7 +106,7 @@ func (q *Querier) GetOne(ctx context.Context, query Sqlizer, dest interface{}) e
 	if err != nil {
 		return wrapErr(err)
 	}
-	return wrapErr(pgxscan.ScanOne(dest, rows))
+	return wrapErr(q.Scan.ScanOne(dest, rows))
 }
 
 func (q *Querier) BatchExec(ctx context.Context, queries Queries) ([]pgconn.CommandTag, error) {
@@ -197,7 +198,7 @@ func (q *Querier) BatchQuery(ctx context.Context, queries Queries) (pgx.BatchRes
 // 	defer batchResults.Close()
 
 // 	// for i, rows := range batchRows {
-// 	// 	err := pgxscan.ScanAll(dest[i], rows)
+// 	// 	err := q.scan.ScanAll(dest[i], rows)
 // 	// 	if err != nil {
 // 	// 		return wrapErr(err)
 // 	// 	}
@@ -208,7 +209,7 @@ func (q *Querier) BatchQuery(ctx context.Context, queries Queries) (pgx.BatchRes
 // 		if err != nil {
 // 			return wrapErr(err)
 // 		}
-// 		err = pgxscan.ScanAll(dest, rows)
+// 		err = q.scan.ScanAll(dest, rows)
 // 		if err != nil {
 // 			return wrapErr(err)
 // 		}

--- a/tests/pgkit_test.go
+++ b/tests/pgkit_test.go
@@ -72,10 +72,10 @@ func TestInsertAndSelectRows(t *testing.T) {
 
 	// Insert
 	insertq, args, err := DB.SQL.Insert("accounts").Columns("name", "disabled").Values("peter", false).ToSql()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = DB.Conn.Exec(context.Background(), insertq, args...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Select all
 	selectq, args := DB.SQL.Select("*").From("accounts").MustSql()
@@ -83,8 +83,8 @@ func TestInsertAndSelectRows(t *testing.T) {
 	var accounts []*Account
 	err = pgxscan.Select(context.Background(), DB.Conn, &accounts, selectq, args...)
 
-	assert.NoError(t, err)
-	assert.Len(t, accounts, 1)
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
 	assert.True(t, accounts[0].ID != 0)
 	assert.Equal(t, "peter", accounts[0].Name)
 }

--- a/tests/pgkit_test.go
+++ b/tests/pgkit_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/goware/pgkit/v2"
 	"github.com/goware/pgkit/v2/db"
 	"github.com/goware/pgkit/v2/dbtype"
@@ -81,7 +80,7 @@ func TestInsertAndSelectRows(t *testing.T) {
 	selectq, args := DB.SQL.Select("*").From("accounts").MustSql()
 
 	var accounts []*Account
-	err = pgxscan.Select(context.Background(), DB.Conn, &accounts, selectq, args...)
+	err = DB.Query.Scan.Select(context.Background(), DB.Conn, &accounts, selectq, args...)
 
 	require.NoError(t, err)
 	require.Len(t, accounts, 1)
@@ -181,7 +180,7 @@ func TestInsertAndSelectRecords(t *testing.T) {
 
 	// Scan result into *Account object
 	a := &Account{}
-	err = pgxscan.ScanOne(a, rows)
+	err = DB.Query.Scan.ScanOne(a, rows)
 	assert.NoError(t, err)
 
 	assert.True(t, a.ID != 0)
@@ -215,7 +214,7 @@ func TestQueryWithNoResults(t *testing.T) {
 
 	// shorthand
 	{
-		err = pgxscan.Select(context.Background(), DB.Conn, &accounts, selectq, args...)
+		err = DB.Query.Scan.Select(context.Background(), DB.Conn, &accounts, selectq, args...)
 		assert.NoError(t, err)
 		assert.Len(t, accounts, 0)
 	}
@@ -226,7 +225,7 @@ func TestQueryWithNoResults(t *testing.T) {
 		defer rows.Close()
 		assert.NoError(t, err)
 
-		err = pgxscan.ScanAll(&accounts, rows)
+		err = DB.Query.Scan.ScanAll(&accounts, rows)
 
 		assert.NoError(t, err)
 		assert.Len(t, accounts, 0)
@@ -235,7 +234,7 @@ func TestQueryWithNoResults(t *testing.T) {
 	// scan one -- returning 'no rows' error
 	{
 		var a *Account
-		err = pgxscan.Get(context.Background(), DB.Conn, a, selectq, args...)
+		err = DB.Query.Scan.Get(context.Background(), DB.Conn, a, selectq, args...)
 		assert.True(t, errors.Is(err, pgx.ErrNoRows))
 	}
 }
@@ -677,7 +676,7 @@ func TestBatchQuery(t *testing.T) {
 		require.NoError(t, err)
 
 		var account Account
-		err = pgxscan.ScanOne(&account, rows)
+		err = DB.Query.Scan.ScanOne(&account, rows)
 		require.NoError(t, err)
 		accounts = append(accounts, &account)
 	}
@@ -714,7 +713,7 @@ func TestSugarBatchQuery(t *testing.T) {
 		require.NoError(t, err)
 
 		var account Account
-		err = pgxscan.ScanOne(&account, rows)
+		err = DB.Query.Scan.ScanOne(&account, rows)
 		require.NoError(t, err)
 		accounts = append(accounts, &account)
 	}
@@ -733,7 +732,7 @@ func TestSugarBatchQuery(t *testing.T) {
 
 		// for _, rows := range batchRows {
 		// 	var account Account
-		// 	err := pgxscan.ScanOne(&account, rows)
+		// 	err := DB.Query.Scan.ScanOne(&account, rows)
 		// 	require.NoError(t, err)
 		// 	accounts = append(accounts, &account)
 		// }

--- a/tests/testdata/pgkit_test_db.sql
+++ b/tests/testdata/pgkit_test_db.sql
@@ -2,6 +2,7 @@ CREATE TABLE accounts (
   id SERIAL PRIMARY KEY,
   name VARCHAR(255),
   disabled BOOLEAN,
+  new_column_not_in_code BOOLEAN, -- test for backward-compatible migrations, see https://github.com/goware/pgkit/issues/13
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 


### PR DESCRIPTION
Fixes #13 -- Pgkit is not backward-compatible when a new column is added to a DB table schema