### PR TITLE
support multiple slices IN clause

### DIFF
--- a/db/cond.go
+++ b/db/cond.go
@@ -273,6 +273,16 @@ func Func[T interface{}](name string, params ...T) squirrel.Sqlizer {
 				places[i] = paramSql
 				args = append(args, paramArgs...)
 			} else {
+				if val, ok := any(param).(driver.Valuer); ok {
+					value, err := val.Value()
+					if err != nil {
+						return "", nil, err
+					}
+					places[i] = paramPlaceholder
+					args = append(args, value)
+					continue
+				}
+
 				places[i] = paramPlaceholder
 				args = append(args, param)
 			}

--- a/db/cond.go
+++ b/db/cond.go
@@ -206,6 +206,35 @@ func In[T interface{}](v ...T) squirrel.Sqlizer {
 	return Func[T]("IN", v...)
 }
 
+// In represents an IN operator. The value must be variadic.
+func InMultiple[T interface{}](v ...[][]T) squirrel.Sqlizer {
+	return sqlExprFn(func() (string, []interface{}, error) {
+		if len(v) == 0 {
+			return "IN ()", nil, nil
+		}
+
+		args := make([]interface{}, 0)
+		sql := "IN ("
+
+		for i, param := range v[0] {
+			sql += "("
+			sql += strings.Repeat("?,", len(param))
+			sql = strings.TrimSuffix(sql, ",")
+			sql += ")"
+			for _, p := range param {
+				args = append(args, p)
+			}
+
+			if len(v[0])-1 != i {
+				sql += ","
+			}
+		}
+		sql += ")"
+
+		return sql, args, nil
+	})
+}
+
 // NotIn represents a NOT IN operator. The value must be variadic.
 func NotIn[T interface{}](v ...T) squirrel.Sqlizer {
 	return Func[T]("NOT IN", v...)

--- a/db/cond_test.go
+++ b/db/cond_test.go
@@ -72,6 +72,15 @@ func TestCond(t *testing.T) {
 		assert.Equal(t, "list IN (?, ?, ?)", s)
 	})
 
+	t.Run("MULTIPLE IN with slice", func(t *testing.T) {
+		cond := db.Cond{"list": db.InMultiple([][]string{{"1", "2", "3"}, {"3", "4", "5"}})}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"1", "2", "3", "3", "4", "5"}, args)
+		assert.Equal(t, "list IN ((?,?,?),(?,?,?))", s)
+	})
+
 	t.Run("NOT IN", func(t *testing.T) {
 		cond := db.Cond{"list": db.NotIn("Czech Republic", "Slovakia")}
 		s, args, err := cond.ToSql()

--- a/db/cond_test.go
+++ b/db/cond_test.go
@@ -81,6 +81,28 @@ func TestCond(t *testing.T) {
 		assert.Equal(t, "list IN ((?,?,?),(?,?,?))", s)
 	})
 
+	t.Run("MULTIPLE IN with struct", func(t *testing.T) {
+		randomStruct := []struct {
+			Id   uint64
+			Name string
+		}{
+			{Id: 1, Name: "Lukas"},
+			{Id: 2, Name: "David"},
+		}
+
+		data := [][]interface{}{}
+		for _, s := range randomStruct {
+			data = append(data, []interface{}{s.Id, s.Name})
+		}
+
+		cond := db.Cond{"list": db.InMultiple(data)}
+		s, args, err := cond.ToSql()
+		require.NoError(t, err)
+
+		assert.Equal(t, []interface{}{uint64(1), "Lukas", uint64(2), "David"}, args)
+		assert.Equal(t, "list IN ((?,?),(?,?))", s)
+	})
+
 	t.Run("NOT IN", func(t *testing.T) {
 		cond := db.Cond{"list": db.NotIn("Czech Republic", "Slovakia")}
 		s, args, err := cond.ToSql()


### PR DESCRIPTION
We wanted to achieve this: 

```
data := [][]any{}
	for _, i := range inputs {
		data = append(data, []any{
			i.ContractAddress,
			i.OrderID,
			i.Marketplace,
		})
	}

	q := sq.
		Select("*").
		From(t.TableName).
		Where(db.Cond{"(contract_address, order_id, marketplace)": db.InMultiples(data)})

	page, q = paginateQuery(page, q)

	var res []*Order
	if err := t.Query.GetAll(ctx, q, &res); err != nil {
		return nil, nil, fmt.Errorf("get all: %w", err)
	}
```

There were few issues with current implementation. 

1.Missing support for driver.Valuer interface ( for instance prototyp.Hash lib is using that ) 
2. Generating `IN cluase` without values is considered wrong. I would be up to return err or just return "", but I was not able to find an easy way how to return empty string "" if `IN clause` has 0 args
3. Missing implementation for multiple IN clauses