### PR TITLE
db.In, db.NotIn support multiple slices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ test: test-clean
 test-all: test-clean
 	GOGC=off go test $(TEST_FLAGS) $(MOD_VENDOR) -run=$(TEST) ./...
 
+test-all-tparse: test-clean
+	GOGC=off go test $(TEST_FLAGS) $(MOD_VENDOR) -run=$(TEST) ./... -json | tparse --follow
+
 test-with-reset: db-reset test-all
+
+test-with-reset-tparse: db-reset test-all-tparse
 
 test-clean:
 	GOGC=off go clean -testcache


### PR DESCRIPTION
Implementation of @LukasJenicek [work](https://github.com/goware/pgkit/pull/20) to `db.Func()` instead of standalone function 