### PR TITLE
go.mod: Downgrade to Go 1.21 as minimal required version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goware/pgkit/v2
 
-go 1.22.3
+go 1.21
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
#17 required Go 1.22.3+. Let's downgrade a bit.

`log/slog` was introduced in Go 1.21.