### PR TITLE
WIP: omitempty bug in InsertRecords

### DIFF
--- a/tests/testdata/pgkit_test_db.sql
+++ b/tests/testdata/pgkit_test_db.sql
@@ -1,6 +1,6 @@
 CREATE TABLE accounts (
   id SERIAL PRIMARY KEY,
-  name VARCHAR(255),
+  name VARCHAR(255) NOT NULL,
   disabled BOOLEAN,
   new_column_not_in_code BOOLEAN, -- test for backward-compatible migrations, see https://github.com/goware/pgkit/issues/13
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL


### PR DESCRIPTION
When you have a table with a field tagged `omitempty`, calling `InsertRecords` will fail if some records have empty values and some do not. The error is `pgkit: ERROR: VALUES lists must all be the same length (SQLSTATE 42601)`. 

This is because the reflection (correctly) ignores the fields tagged `omitempty`, which results in different fields being supplied for the insert statement. 

https://github.com/goware/pgkit/blob/master/builder.go#L51
https://github.com/goware/pgkit/blob/master/mapper.go#L41

NOTE: This PR is only to share the failing test case. 