### PR TITLE
represent slice of uints as hex string

### DIFF
--- a/examples/tracing/go.sum
+++ b/examples/tracing/go.sum
@@ -9,6 +9,7 @@ github.com/georgysavva/scany/v2 v2.1.0 h1:jEAX+yPQ2AAtnv0WJzAYlgsM/KzvwbD6BjSjLI
 github.com/georgysavva/scany/v2 v2.1.0/go.mod h1:fqp9yHZzM/PFVa3/rYEC57VmDx+KDch0LoqrJzkvtos=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/goware/pgkit/v2 v2.1.0/go.mod h1:8uQAUVpu77LxacfS94pPGsmqidVn3kj4M8Fg8RnaB84=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=


### PR DESCRIPTION
Format:
- []uint8 as hex
- format time correct ISO
- use single quotes where necessary to be compliant with postgres

Examples:

![image](https://github.com/user-attachments/assets/950968de-fe11-46e1-8b53-074352792f16)

It can handle more complex queries now: 

```
S args : 14 []interface {}
     0: 43113
     1: 0x5425890298aed601595a70ab815c96711a31bc65
     2: 2025-01-14 09:06:21.384727 +0000 UTC
     3: 6
     4: true
     5: <nil>
     6: 1
     7: 4
     8: https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png
     9: USD Coin
    10: false
    11: USDC
    12: 2025-01-17 17:03:59.614270958 +0000 UTC
    13: 4
  query: UPDATE currencies SET chain_id = 43113, contract_address = 0x5425890298aed601595a70ab815c96711a31bc65, created_at = '2025-01-14 09:06:21.384727', decimals = 6, default_chain_currency = true, deleted_at = NULL, exchange_rate = 1.000000, id = 4, image_url = 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png', name = 'USD Coin', native_currency = false, symbol = 'USDC', updated_at = '2025-01-17 17:03:59.614270' WHERE id = 4
```
 

