### PR TITLE
Prevent SQL injection when passing Sort

### DIFF
--- a/page_test.go
+++ b/page_test.go
@@ -58,7 +58,6 @@ func TestInvalidSort(t *testing.T) {
 
 	sql, args, err := query.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t ORDER BY name DESC LIMIT 11 OFFSET 0", sql)
+	require.Equal(t, "SELECT * FROM t ORDER BY \"ID; DROP TABLE users;\" ASC, \"name\" DESC LIMIT 11 OFFSET 0", sql)
 	require.Empty(t, args)
-
 }

--- a/page_test.go
+++ b/page_test.go
@@ -17,7 +17,7 @@ func TestPagination(t *testing.T) {
 		MaxSize     = 5
 		Sort        = "ID"
 	)
-	paginator := pgkit.NewPaginator[T](
+	paginator := pgkit.NewPaginator(
 		pgkit.WithColumnFunc[T](strings.ToLower),
 		pgkit.WithDefaultSize[T](DefaultSize),
 		pgkit.WithMaxSize[T](MaxSize),
@@ -44,4 +44,21 @@ func TestPagination(t *testing.T) {
 	result = paginator.PrepareResult(make([]T, MaxSize+2), page)
 	require.Len(t, result, MaxSize)
 	require.Equal(t, &pgkit.Page{Page: 1, Size: MaxSize, More: true}, page)
+}
+
+func TestInvalidSort(t *testing.T) {
+	paginator := pgkit.NewPaginator[T]()
+	page := pgkit.NewPage(0, 0)
+	page.Sort = []pgkit.Sort{
+		{Column: "ID; DROP TABLE users;", Order: pgkit.Asc},
+		{Column: "name", Order: pgkit.Desc},
+	}
+
+	_, query := paginator.PrepareQuery(sq.Select("*").From("t"), page)
+
+	sql, args, err := query.ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT * FROM t ORDER BY name DESC LIMIT 11 OFFSET 0", sql)
+	require.Empty(t, args)
+
 }


### PR DESCRIPTION
```go
package main

import (
	"fmt"

	sq "github.com/Masterminds/squirrel"
	"github.com/goware/pgkit/v2"
)

func main() {
	page := pgkit.Page{
		Sort: []pgkit.Sort{
			{Column: "ID; DROP TABLE users;", Order: pgkit.Asc},
		}
	}
	_, q := pgkit.NewPaginator[T]().PrepareQuery(sq.Select("*").From("t"), page)
	sql, _, _ := q.ToSql()

	fmt.Println(sql)
}
```

Produces:

```SQL
SELECT * FROM t ORDER BY ID; DROP TABLE users; ASC
```