### PR TITLE
fix: Iter yields all rows instead of only the first

### DIFF
--- a/table.go
+++ b/table.go
@@ -417,10 +417,8 @@ func (t *Table[T, P, I]) Iter(ctx context.Context, where sq.Sqlizer, orderBy []s
 		defer rows.Close()
 		for rows.Next() {
 			var record T
-			if err := t.Query.Scan.ScanOne(&record, rows); err != nil {
-				if !errors.Is(err, pgx.ErrNoRows) {
-					yield(nil, err)
-				}
+			if err := t.Query.Scan.ScanRow(&record, rows); err != nil {
+				yield(nil, err)
 				return
 			}
 			if !yield(&record, nil) {

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -619,6 +619,34 @@ func TestHardDeleteByID(t *testing.T) {
 	})
 }
 
+func TestIter(t *testing.T) {
+	truncateAllTables(t)
+
+	ctx := t.Context()
+	db := initDB(DB)
+
+	account := &Account{Name: "Iter Account"}
+	err := db.Accounts.Insert(ctx, account)
+	require.NoError(t, err)
+
+	const total = 100
+	for i := range total {
+		err := db.Articles.Insert(ctx, &Article{AccountID: account.ID, Author: fmt.Sprintf("Author %03d", i)})
+		require.NoError(t, err)
+	}
+
+	iter, err := db.Articles.Iter(ctx, sq.Eq{"account_id": account.ID}, []string{"id"})
+	require.NoError(t, err)
+
+	var count int
+	for article, err := range iter {
+		require.NoError(t, err)
+		require.NotNil(t, article)
+		count++
+	}
+	require.Equal(t, total, count, "Iter should yield all rows")
+}
+
 func TestLockForUpdates(t *testing.T) {
 	truncateAllTables(t)
 


### PR DESCRIPTION
## Summary

- **Bug**: `Iter` used scany's `ScanOne` which closes `pgx.Rows` after scanning the first row, making the iterator yield only one row then stop.
- **Fix**: Replace `ScanOne` with `ScanRow`, which scans the current row without closing the cursor.
- **Test**: Added `TestIter` — inserts 100 rows, iterates with `Iter`, asserts count is 100.

## Test plan

- [x] `TestIter` passes (100 rows streamed)
- [x] Full test suite passes (24 tests, 0 failures)