### PR TITLE
MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-present https://github.com/goware authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pgkit
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/goware/pgkit/v2.svg)](https://pkg.go.dev/github.com/goware/pgkit/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goware/pgkit/v2)](https://goreportcard.com/report/github.com/goware/pgkit/v2)
-[![Apache 2.0 License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg)](LICENSE)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 lightweight PostgreSQL sugar combining the use of..
 
@@ -21,4 +21,4 @@ Please see [./tests/pgkit_test.go](./tests/pgkit_test.go)
 
 ## LICENSE
 
-Apache 2.0
+[MIT](./LICENSE)


### PR DESCRIPTION
- Switch from Apache 2.0 to MIT
- Add LICENSE file to the git repo, so https://pkg.go.dev/github.com/goware/pgkit/v2 works

Needs review from the main author @pkieltyka; and ideally from a couple of contributors too @klaidliadon @david-littlefarmer @attente @david-littlefarmer @LukasJenicek @xiam @marino39 @VojtechVitek.