### PR TITLE
feat: CursorPaginator for keyset pagination

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -15,8 +15,8 @@ var (
 	ErrInvalidCursor = errors.New("invalid cursor")
 	// ErrCursorQueryOrdered signals a cursor-paginated query that already had ORDER BY.
 	ErrCursorQueryOrdered = errors.New("cursor query already has order by")
-	// ErrCursorPageOrdered signals cursor pagination with page-level ordering.
-	ErrCursorPageOrdered = errors.New("cursor page already has order")
+	// ErrCursorPageOrdered signals page-level ordering that does not match the cursor order.
+	ErrCursorPageOrdered = errors.New("cursor page order does not match cursor order")
 )
 
 // EncodeCursor produces an opaque cursor: base64-JSON, not signed, never use it for authorization.
@@ -49,6 +49,7 @@ type Cursor[Self any, Row any] interface {
 	PtrTo[Self]
 	Apply(sq.SelectBuilder) sq.SelectBuilder
 	From(Row) error
+	// OrderBy must match Apply and should include a unique tiebreaker.
 	OrderBy() []Sort
 }
 
@@ -79,14 +80,21 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 	}
 	page.SetDefaults(&p.settings)
 
-	if page.Column != "" || len(page.Sort) != 0 {
-		return nil, q, ErrCursorPageOrdered
-	}
 	if _, ok := builder.Get(q, "OrderByParts"); ok {
 		return nil, q, ErrCursorQueryOrdered
 	}
 	var zero C
-	for _, sort := range PC(&zero).OrderBy() {
+	order := PC(&zero).OrderBy()
+	pageOrder := page.GetOrder(nil)
+	if len(pageOrder) != 0 && len(pageOrder) != len(order) {
+		return nil, q, ErrCursorPageOrdered
+	}
+	for i := range pageOrder {
+		if pageOrder[i] != order[i].sanitize(nil) {
+			return nil, q, ErrCursorPageOrdered
+		}
+	}
+	for _, sort := range order {
 		q = q.OrderBy(sort.String())
 	}
 	if page.Cursor != "" {

--- a/cursor.go
+++ b/cursor.go
@@ -111,8 +111,8 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 	return make([]T, 0, limit+1), q, nil
 }
 
-// List returns cursor-paginated rows and the page populated with More and NextCursor.
-func (p CursorPaginator[T, C, PC]) List(ctx context.Context, query *Querier, q sq.SelectBuilder, page *Page) ([]T, *Page, error) {
+// Paginate returns cursor-paginated rows and the page populated with More and NextCursor.
+func (p CursorPaginator[T, C, PC]) Paginate(ctx context.Context, query *Querier, q sq.SelectBuilder, page *Page) ([]T, *Page, error) {
 	if page == nil {
 		page = &Page{}
 	}

--- a/cursor.go
+++ b/cursor.go
@@ -37,14 +37,21 @@ func DecodeCursor[C any](value string) (*C, error) {
 	return &cursor, nil
 }
 
+// Cursor is the interface a typed keyset cursor satisfies — mirrors pgkit.Record[T, I]'s self-pointer pattern.
+type Cursor[Self any, Row any] interface {
+	*Self
+	Apply(sq.SelectBuilder) sq.SelectBuilder
+	From(Row) error
+}
+
 // CursorPaginator is the keyset sibling of Paginator[T] for ordering-stable pagination under concurrent writes.
-// The caller owns ORDER BY; applyCursor must match it or pages will silently skip or duplicate rows.
-type CursorPaginator[T any, C any] struct {
+// The caller owns ORDER BY; C.Apply must match it or pages will silently skip or duplicate rows.
+type CursorPaginator[T any, C any, PC Cursor[C, T]] struct {
 	settings PaginatorSettings
 }
 
 // NewCursorPaginator honors only size options — WithSort / WithColumnFunc are no-ops because the caller owns ORDER BY.
-func NewCursorPaginator[T any, C any](options ...PaginatorOption) CursorPaginator[T, C] {
+func NewCursorPaginator[T any, C any, PC Cursor[C, T]](options ...PaginatorOption) CursorPaginator[T, C, PC] {
 	settings := &PaginatorSettings{
 		DefaultSize: DefaultPageSize,
 		MaxSize:     MaxPageSize,
@@ -55,18 +62,11 @@ func NewCursorPaginator[T any, C any](options ...PaginatorOption) CursorPaginato
 	if settings.MaxSize < settings.DefaultSize {
 		settings.MaxSize = settings.DefaultSize
 	}
-	return CursorPaginator[T, C]{settings: *settings}
+	return CursorPaginator[T, C, PC]{settings: *settings}
 }
 
 // PrepareQuery chains LIMIT n+1 so PrepareResult can detect a next page without a second round-trip.
-func (p CursorPaginator[T, C]) PrepareQuery(
-	q sq.SelectBuilder,
-	page *Page,
-	applyCursor func(sq.SelectBuilder, C) sq.SelectBuilder,
-) ([]T, sq.SelectBuilder, error) {
-	if applyCursor == nil {
-		panic("pgkit: CursorPaginator.PrepareQuery: applyCursor must not be nil")
-	}
+func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) ([]T, sq.SelectBuilder, error) {
 	if page == nil {
 		page = &Page{}
 	}
@@ -77,7 +77,7 @@ func (p CursorPaginator[T, C]) PrepareQuery(
 		if err != nil {
 			return nil, q, err
 		}
-		q = applyCursor(q, *cursor)
+		q = PC(cursor).Apply(q)
 	}
 
 	limit := page.Limit()
@@ -86,20 +86,13 @@ func (p CursorPaginator[T, C]) PrepareQuery(
 }
 
 // PrepareResult must be called after GetAll to populate page.More and page.NextCursor.
-func (p CursorPaginator[T, C]) PrepareResult(
-	result []T,
-	page *Page,
-	cursorFromRow func(T) (C, error),
-) ([]T, error) {
-	if cursorFromRow == nil {
-		panic("pgkit: CursorPaginator.PrepareResult: cursorFromRow must not be nil")
-	}
+func (p CursorPaginator[T, C, PC]) PrepareResult(result []T, page *Page) ([]T, error) {
 	limit := int(page.Limit())
 	page.More = len(result) > limit
 	if page.More {
 		result = result[:limit]
-		cursor, err := cursorFromRow(result[len(result)-1])
-		if err != nil {
+		var cursor C
+		if err := PC(&cursor).From(result[len(result)-1]); err != nil {
 			return nil, fmt.Errorf("cursor from row: %w", err)
 		}
 		next, err := EncodeCursor(cursor)

--- a/cursor.go
+++ b/cursor.go
@@ -1,0 +1,113 @@
+package pgkit
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// ErrInvalidCursor signals a client-supplied cursor that failed to decode — map to 400, not 500.
+var ErrInvalidCursor = errors.New("invalid cursor")
+
+// EncodeCursor produces an opaque cursor: base64-JSON, not signed, never use it for authorization.
+func EncodeCursor[C any](cursor C) (string, error) {
+	raw, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("marshal cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// DecodeCursor returns (nil, nil) for empty input so callers can compose with a nil-check.
+func DecodeCursor[C any](value string) (*C, error) {
+	if value == "" {
+		return nil, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return nil, ErrInvalidCursor
+	}
+	var cursor C
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return nil, ErrInvalidCursor
+	}
+	return &cursor, nil
+}
+
+// CursorPaginator is the keyset sibling of Paginator[T] for ordering-stable pagination under concurrent writes.
+// The caller owns ORDER BY; applyCursor must match it or pages will silently skip or duplicate rows.
+type CursorPaginator[T any, C any] struct {
+	settings PaginatorSettings
+}
+
+// NewCursorPaginator honors only size options — WithSort / WithColumnFunc are no-ops because the caller owns ORDER BY.
+func NewCursorPaginator[T any, C any](options ...PaginatorOption) CursorPaginator[T, C] {
+	settings := &PaginatorSettings{
+		DefaultSize: DefaultPageSize,
+		MaxSize:     MaxPageSize,
+	}
+	for _, option := range options {
+		option(settings)
+	}
+	if settings.MaxSize < settings.DefaultSize {
+		settings.MaxSize = settings.DefaultSize
+	}
+	return CursorPaginator[T, C]{settings: *settings}
+}
+
+// PrepareQuery chains LIMIT n+1 so PrepareResult can detect a next page without a second round-trip.
+func (p CursorPaginator[T, C]) PrepareQuery(
+	q sq.SelectBuilder,
+	page *Page,
+	applyCursor func(sq.SelectBuilder, C) sq.SelectBuilder,
+) ([]T, sq.SelectBuilder, error) {
+	if applyCursor == nil {
+		panic("pgkit: CursorPaginator.PrepareQuery: applyCursor must not be nil")
+	}
+	if page == nil {
+		page = &Page{}
+	}
+	page.SetDefaults(&p.settings)
+
+	if page.Cursor != "" {
+		cursor, err := DecodeCursor[C](page.Cursor)
+		if err != nil {
+			return nil, q, err
+		}
+		q = applyCursor(q, *cursor)
+	}
+
+	limit := page.Limit()
+	q = q.Limit(limit + 1)
+	return make([]T, 0, limit+1), q, nil
+}
+
+// PrepareResult must be called after GetAll to populate page.More and page.NextCursor.
+func (p CursorPaginator[T, C]) PrepareResult(
+	result []T,
+	page *Page,
+	cursorFromRow func(T) (C, error),
+) ([]T, error) {
+	if cursorFromRow == nil {
+		panic("pgkit: CursorPaginator.PrepareResult: cursorFromRow must not be nil")
+	}
+	limit := int(page.Limit())
+	page.More = len(result) > limit
+	if page.More {
+		result = result[:limit]
+		cursor, err := cursorFromRow(result[len(result)-1])
+		if err != nil {
+			return nil, fmt.Errorf("cursor from row: %w", err)
+		}
+		next, err := EncodeCursor(cursor)
+		if err != nil {
+			return nil, err
+		}
+		page.NextCursor = next
+	}
+	page.Size = uint32(limit)
+	return result, nil
+}

--- a/cursor.go
+++ b/cursor.go
@@ -7,10 +7,15 @@ import (
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/lann/builder"
 )
 
-// ErrInvalidCursor signals a client-supplied cursor that failed to decode — map to 400, not 500.
-var ErrInvalidCursor = errors.New("invalid cursor")
+var (
+	// ErrInvalidCursor signals a client-supplied cursor that failed to decode - map to 400, not 500.
+	ErrInvalidCursor = errors.New("invalid cursor")
+	// ErrCursorQueryOrdered signals a cursor-paginated query that already had ORDER BY.
+	ErrCursorQueryOrdered = errors.New("cursor query already has order by")
+)
 
 // EncodeCursor produces an opaque cursor: base64-JSON, not signed, never use it for authorization.
 func EncodeCursor[C any](cursor C) (string, error) {
@@ -39,18 +44,18 @@ func DecodeCursor[C any](value string) (*C, error) {
 
 // Cursor is the interface a typed keyset cursor satisfies — mirrors pgkit.Record[T, I]'s self-pointer pattern.
 type Cursor[Self any, Row any] interface {
-	*Self
+	PtrTo[Self]
 	Apply(sq.SelectBuilder) sq.SelectBuilder
 	From(Row) error
+	OrderBy() []Sort
 }
 
 // CursorPaginator is the keyset sibling of Paginator[T] for ordering-stable pagination under concurrent writes.
-// The caller owns ORDER BY; C.Apply must match it or pages will silently skip or duplicate rows.
 type CursorPaginator[T any, C any, PC Cursor[C, T]] struct {
 	settings PaginatorSettings
 }
 
-// NewCursorPaginator honors only size options — WithSort / WithColumnFunc are no-ops because the caller owns ORDER BY.
+// NewCursorPaginator honors only size options - the cursor owns ORDER BY.
 func NewCursorPaginator[T any, C any, PC Cursor[C, T]](options ...PaginatorOption) CursorPaginator[T, C, PC] {
 	settings := &PaginatorSettings{
 		DefaultSize: DefaultPageSize,
@@ -72,6 +77,13 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 	}
 	page.SetDefaults(&p.settings)
 
+	if _, ok := builder.Get(q, "OrderByParts"); ok {
+		return nil, q, ErrCursorQueryOrdered
+	}
+	var zero C
+	for _, sort := range PC(&zero).OrderBy() {
+		q = q.OrderBy(sort.String())
+	}
 	if page.Cursor != "" {
 		cursor, err := DecodeCursor[C](page.Cursor)
 		if err != nil {

--- a/cursor.go
+++ b/cursor.go
@@ -88,19 +88,21 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 // PrepareResult must be called after GetAll to populate page.More and page.NextCursor.
 func (p CursorPaginator[T, C, PC]) PrepareResult(result []T, page *Page) ([]T, error) {
 	limit := int(page.Limit())
-	page.More = len(result) > limit
-	if page.More {
-		result = result[:limit]
-		var cursor C
-		if err := PC(&cursor).From(result[len(result)-1]); err != nil {
-			return nil, fmt.Errorf("cursor from row: %w", err)
-		}
-		next, err := EncodeCursor(cursor)
-		if err != nil {
-			return nil, err
-		}
-		page.NextCursor = next
-	}
 	page.Size = uint32(limit)
+	page.More = len(result) > limit
+	if !page.More {
+		return result, nil
+	}
+	result = result[:limit]
+
+	var cursor C
+	if err := PC(&cursor).From(result[len(result)-1]); err != nil {
+		return nil, fmt.Errorf("cursor from row: %w", err)
+	}
+	next, err := EncodeCursor(cursor)
+	if err != nil {
+		return nil, err
+	}
+	page.NextCursor = next
 	return result, nil
 }

--- a/cursor.go
+++ b/cursor.go
@@ -1,6 +1,7 @@
 package pgkit
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -108,6 +109,25 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 	limit := page.Limit()
 	q = q.Limit(limit + 1)
 	return make([]T, 0, limit+1), q, nil
+}
+
+// List returns cursor-paginated rows and the page populated with More and NextCursor.
+func (p CursorPaginator[T, C, PC]) List(ctx context.Context, query *Querier, q sq.SelectBuilder, page *Page) ([]T, *Page, error) {
+	if page == nil {
+		page = &Page{}
+	}
+	result, q, err := p.PrepareQuery(q, page)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := query.GetAll(ctx, q, &result); err != nil {
+		return nil, nil, err
+	}
+	result, err = p.PrepareResult(result, page)
+	if err != nil {
+		return nil, nil, err
+	}
+	return result, page, nil
 }
 
 // PrepareResult must be called after GetAll to populate page.More and page.NextCursor.

--- a/cursor.go
+++ b/cursor.go
@@ -15,6 +15,8 @@ var (
 	ErrInvalidCursor = errors.New("invalid cursor")
 	// ErrCursorQueryOrdered signals a cursor-paginated query that already had ORDER BY.
 	ErrCursorQueryOrdered = errors.New("cursor query already has order by")
+	// ErrCursorPageOrdered signals cursor pagination with page-level ordering.
+	ErrCursorPageOrdered = errors.New("cursor page already has order")
 )
 
 // EncodeCursor produces an opaque cursor: base64-JSON, not signed, never use it for authorization.
@@ -77,6 +79,9 @@ func (p CursorPaginator[T, C, PC]) PrepareQuery(q sq.SelectBuilder, page *Page) 
 	}
 	page.SetDefaults(&p.settings)
 
+	if page.Column != "" || len(page.Sort) != 0 {
+		return nil, q, ErrCursorPageOrdered
+	}
 	if _, ok := builder.Get(q, "OrderByParts"); ok {
 		return nil, q, ErrCursorQueryOrdered
 	}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -11,20 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type rowCursor struct {
-	ID string `json:"id"`
-}
-
 type row struct {
 	ID string
 }
 
-func applyIDCursor(q sq.SelectBuilder, c rowCursor) sq.SelectBuilder {
+type rowCursor struct {
+	ID string `json:"id"`
+}
+
+func (c *rowCursor) Apply(q sq.SelectBuilder) sq.SelectBuilder {
 	return q.Where(sq.Lt{"id": c.ID})
 }
 
-func cursorFromRow(r row) (rowCursor, error) {
-	return rowCursor{ID: r.ID}, nil
+func (c *rowCursor) From(r row) error {
+	c.ID = r.ID
+	return nil
 }
 
 func TestEncodeDecodeCursorRoundTrip(t *testing.T) {
@@ -51,7 +52,6 @@ func TestDecodeCursorInvalidBase64(t *testing.T) {
 }
 
 func TestDecodeCursorInvalidJSON(t *testing.T) {
-	// Valid base64, invalid JSON payload.
 	encoded, err := pgkit.EncodeCursor("not a struct")
 	require.NoError(t, err)
 
@@ -61,13 +61,13 @@ func TestDecodeCursorInvalidJSON(t *testing.T) {
 }
 
 func TestCursorPaginatorFirstPage(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](
 		pgkit.WithDefaultSize(2),
 		pgkit.WithMaxSize(5),
 	)
 	page := &pgkit.Page{}
 
-	result, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	result, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 	require.Len(t, result, 0)
 	require.Equal(t, 3, cap(result))
@@ -79,12 +79,12 @@ func TestCursorPaginatorFirstPage(t *testing.T) {
 }
 
 func TestCursorPaginatorWithCursor(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](pgkit.WithDefaultSize(2))
 	encoded, err := pgkit.EncodeCursor(rowCursor{ID: "row_5"})
 	require.NoError(t, err)
 	page := &pgkit.Page{Cursor: encoded}
 
-	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
 	sql, args, err := q.ToSql()
@@ -94,21 +94,21 @@ func TestCursorPaginatorWithCursor(t *testing.T) {
 }
 
 func TestCursorPaginatorInvalidCursor(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
 	page := &pgkit.Page{Cursor: "!!!not-base64!!!"}
 
-	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, pgkit.ErrInvalidCursor))
 }
 
 func TestCursorPaginatorPrepareResultNoMore(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(3))
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](pgkit.WithDefaultSize(3))
 	page := &pgkit.Page{}
-	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
-	result, err := paginator.PrepareResult([]row{{ID: "1"}, {ID: "2"}}, page, cursorFromRow)
+	result, err := paginator.PrepareResult([]row{{ID: "1"}, {ID: "2"}}, page)
 	require.NoError(t, err)
 	require.Len(t, result, 2)
 	require.False(t, page.More)
@@ -117,23 +117,20 @@ func TestCursorPaginatorPrepareResultNoMore(t *testing.T) {
 }
 
 func TestCursorPaginatorPrepareResultHasMore(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](pgkit.WithDefaultSize(2))
 	page := &pgkit.Page{}
-	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
-	// Three rows returned, limit was 2 — the third signals "more".
 	result, err := paginator.PrepareResult(
 		[]row{{ID: "3"}, {ID: "2"}, {ID: "1"}},
 		page,
-		cursorFromRow,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []row{{ID: "3"}, {ID: "2"}}, result)
 	require.True(t, page.More)
 	require.NotEmpty(t, page.NextCursor)
 
-	// NextCursor must round-trip back to the last surviving row.
 	decoded, err := pgkit.DecodeCursor[rowCursor](page.NextCursor)
 	require.NoError(t, err)
 	require.NotNil(t, decoded)
@@ -141,24 +138,23 @@ func TestCursorPaginatorPrepareResultHasMore(t *testing.T) {
 }
 
 func TestCursorPaginatorDefaultsFromNilPage(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
-	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), nil, applyIDCursor)
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), nil)
 	require.NoError(t, err)
 
 	sql, _, err := q.ToSql()
 	require.NoError(t, err)
-	// Default page size is 10 → LIMIT 11.
 	require.Equal(t, "SELECT * FROM t LIMIT 11", sql)
 }
 
 func TestCursorPaginatorCapsAtMaxSize(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](
 		pgkit.WithDefaultSize(5),
 		pgkit.WithMaxSize(10),
 	)
 	page := &pgkit.Page{Size: 999}
 
-	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
 	sql, _, err := q.ToSql()
@@ -168,25 +164,22 @@ func TestCursorPaginatorCapsAtMaxSize(t *testing.T) {
 }
 
 func TestCursorPaginatorMaxSizeBelowDefaultIsLifted(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](
 		pgkit.WithDefaultSize(20),
 		pgkit.WithMaxSize(5),
 	)
 	page := &pgkit.Page{}
 
-	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
 	sql, _, err := q.ToSql()
 	require.NoError(t, err)
-	// MaxSize is lifted to DefaultSize, so DefaultSize wins → LIMIT 21.
 	require.Equal(t, "SELECT * FROM t LIMIT 21", sql)
 }
 
 func TestCursorPaginatorWalksPages(t *testing.T) {
-	// End-to-end: paginate a fixed 5-row dataset in pages of 2 and
-	// verify every row surfaces exactly once across three pages.
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor](pgkit.WithDefaultSize(2))
 	all := []row{{ID: "5"}, {ID: "4"}, {ID: "3"}, {ID: "2"}, {ID: "1"}}
 
 	var (
@@ -194,11 +187,11 @@ func TestCursorPaginatorWalksPages(t *testing.T) {
 		seen []row
 	)
 	for step := 0; step < 5; step++ {
-		_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+		_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 		require.NoError(t, err)
 
 		fetched := fetch(t, all, q)
-		got, err := paginator.PrepareResult(fetched, page, cursorFromRow)
+		got, err := paginator.PrepareResult(fetched, page)
 		require.NoError(t, err)
 
 		seen = append(seen, got...)
@@ -212,41 +205,29 @@ func TestCursorPaginatorWalksPages(t *testing.T) {
 	require.False(t, page.More)
 }
 
+type failingRowCursor struct {
+	ID string `json:"id"`
+}
+
+func (c *failingRowCursor) Apply(q sq.SelectBuilder) sq.SelectBuilder {
+	return q.Where(sq.Lt{"id": c.ID})
+}
+
+var errBoom = errors.New("boom")
+
+func (c *failingRowCursor) From(row) error {
+	return errBoom
+}
+
 func TestCursorPaginatorPrepareResultPropagatesCursorError(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(1))
+	paginator := pgkit.NewCursorPaginator[row, failingRowCursor, *failingRowCursor](pgkit.WithDefaultSize(1))
 	page := &pgkit.Page{}
-	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page)
 	require.NoError(t, err)
 
-	sentinel := errors.New("boom")
-	_, err = paginator.PrepareResult(
-		[]row{{ID: "2"}, {ID: "1"}},
-		page,
-		func(row) (rowCursor, error) { return rowCursor{}, sentinel },
-	)
+	_, err = paginator.PrepareResult([]row{{ID: "2"}, {ID: "1"}}, page)
 	require.Error(t, err)
-	require.True(t, errors.Is(err, sentinel))
-}
-
-func TestCursorPaginatorPanicsOnNilApplyCursor(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
-	require.PanicsWithValue(
-		t,
-		"pgkit: CursorPaginator.PrepareQuery: applyCursor must not be nil",
-		func() { _, _, _ = paginator.PrepareQuery(sq.Select("*").From("t"), &pgkit.Page{}, nil) },
-	)
-}
-
-func TestCursorPaginatorPanicsOnNilCursorFromRow(t *testing.T) {
-	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
-	page := &pgkit.Page{}
-	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
-	require.NoError(t, err)
-	require.PanicsWithValue(
-		t,
-		"pgkit: CursorPaginator.PrepareResult: cursorFromRow must not be nil",
-		func() { _, _ = paginator.PrepareResult([]row{{ID: "1"}}, page, nil) },
-	)
+	require.True(t, errors.Is(err, errBoom))
 }
 
 // In-memory stand-in so the pagination walk exercises encode/decode without a real database.

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -23,6 +23,10 @@ func (c *rowCursor) Apply(q sq.SelectBuilder) sq.SelectBuilder {
 	return q.Where(sq.Lt{"id": c.ID})
 }
 
+func (c *rowCursor) OrderBy() []pgkit.Sort {
+	return []pgkit.Sort{{Column: "id", Order: pgkit.Desc}}
+}
+
 func (c *rowCursor) From(r row) error {
 	c.ID = r.ID
 	return nil
@@ -74,7 +78,7 @@ func TestCursorPaginatorFirstPage(t *testing.T) {
 
 	sql, args, err := q.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t LIMIT 3", sql)
+	require.Equal(t, `SELECT * FROM t ORDER BY "id" DESC LIMIT 3`, sql)
 	require.Empty(t, args)
 }
 
@@ -89,8 +93,15 @@ func TestCursorPaginatorWithCursor(t *testing.T) {
 
 	sql, args, err := q.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t WHERE id < ? LIMIT 3", sql)
+	require.Equal(t, `SELECT * FROM t WHERE id < ? ORDER BY "id" DESC LIMIT 3`, sql)
 	require.Equal(t, []any{"row_5"}, args)
+}
+
+func TestCursorPaginatorRejectsPreorderedQuery(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
+
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t").OrderBy("name"), &pgkit.Page{})
+	require.ErrorIs(t, err, pgkit.ErrCursorQueryOrdered)
 }
 
 func TestCursorPaginatorInvalidCursor(t *testing.T) {
@@ -144,7 +155,7 @@ func TestCursorPaginatorDefaultsFromNilPage(t *testing.T) {
 
 	sql, _, err := q.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t LIMIT 11", sql)
+	require.Equal(t, `SELECT * FROM t ORDER BY "id" DESC LIMIT 11`, sql)
 }
 
 func TestCursorPaginatorCapsAtMaxSize(t *testing.T) {
@@ -159,7 +170,7 @@ func TestCursorPaginatorCapsAtMaxSize(t *testing.T) {
 
 	sql, _, err := q.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t LIMIT 11", sql)
+	require.Equal(t, `SELECT * FROM t ORDER BY "id" DESC LIMIT 11`, sql)
 	require.Equal(t, uint32(10), page.Size)
 }
 
@@ -175,7 +186,7 @@ func TestCursorPaginatorMaxSizeBelowDefaultIsLifted(t *testing.T) {
 
 	sql, _, err := q.ToSql()
 	require.NoError(t, err)
-	require.Equal(t, "SELECT * FROM t LIMIT 21", sql)
+	require.Equal(t, `SELECT * FROM t ORDER BY "id" DESC LIMIT 21`, sql)
 }
 
 func TestCursorPaginatorWalksPages(t *testing.T) {
@@ -211,6 +222,10 @@ type failingRowCursor struct {
 
 func (c *failingRowCursor) Apply(q sq.SelectBuilder) sq.SelectBuilder {
 	return q.Where(sq.Lt{"id": c.ID})
+}
+
+func (c *failingRowCursor) OrderBy() []pgkit.Sort {
+	return []pgkit.Sort{{Column: "id", Order: pgkit.Desc}}
 }
 
 var errBoom = errors.New("boom")

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -1,0 +1,277 @@
+package pgkit_test
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/goware/pgkit/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type rowCursor struct {
+	ID string `json:"id"`
+}
+
+type row struct {
+	ID string
+}
+
+func applyIDCursor(q sq.SelectBuilder, c rowCursor) sq.SelectBuilder {
+	return q.Where(sq.Lt{"id": c.ID})
+}
+
+func cursorFromRow(r row) (rowCursor, error) {
+	return rowCursor{ID: r.ID}, nil
+}
+
+func TestEncodeDecodeCursorRoundTrip(t *testing.T) {
+	encoded, err := pgkit.EncodeCursor(rowCursor{ID: "row_1"})
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	decoded, err := pgkit.DecodeCursor[rowCursor](encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+	require.Equal(t, "row_1", decoded.ID)
+}
+
+func TestDecodeCursorEmptyReturnsNil(t *testing.T) {
+	decoded, err := pgkit.DecodeCursor[rowCursor]("")
+	require.NoError(t, err)
+	require.Nil(t, decoded)
+}
+
+func TestDecodeCursorInvalidBase64(t *testing.T) {
+	_, err := pgkit.DecodeCursor[rowCursor]("!!!not-base64!!!")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, pgkit.ErrInvalidCursor))
+}
+
+func TestDecodeCursorInvalidJSON(t *testing.T) {
+	// Valid base64, invalid JSON payload.
+	encoded, err := pgkit.EncodeCursor("not a struct")
+	require.NoError(t, err)
+
+	_, err = pgkit.DecodeCursor[rowCursor](encoded)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, pgkit.ErrInvalidCursor))
+}
+
+func TestCursorPaginatorFirstPage(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+		pgkit.WithDefaultSize(2),
+		pgkit.WithMaxSize(5),
+	)
+	page := &pgkit.Page{}
+
+	result, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+	require.Len(t, result, 0)
+	require.Equal(t, 3, cap(result))
+
+	sql, args, err := q.ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT * FROM t LIMIT 3", sql)
+	require.Empty(t, args)
+}
+
+func TestCursorPaginatorWithCursor(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	encoded, err := pgkit.EncodeCursor(rowCursor{ID: "row_5"})
+	require.NoError(t, err)
+	page := &pgkit.Page{Cursor: encoded}
+
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	sql, args, err := q.ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT * FROM t WHERE id < ? LIMIT 3", sql)
+	require.Equal(t, []any{"row_5"}, args)
+}
+
+func TestCursorPaginatorInvalidCursor(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
+	page := &pgkit.Page{Cursor: "!!!not-base64!!!"}
+
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, pgkit.ErrInvalidCursor))
+}
+
+func TestCursorPaginatorPrepareResultNoMore(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(3))
+	page := &pgkit.Page{}
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	result, err := paginator.PrepareResult([]row{{ID: "1"}, {ID: "2"}}, page, cursorFromRow)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.False(t, page.More)
+	require.Empty(t, page.NextCursor)
+	require.Equal(t, uint32(3), page.Size)
+}
+
+func TestCursorPaginatorPrepareResultHasMore(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	page := &pgkit.Page{}
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	// Three rows returned, limit was 2 — the third signals "more".
+	result, err := paginator.PrepareResult(
+		[]row{{ID: "3"}, {ID: "2"}, {ID: "1"}},
+		page,
+		cursorFromRow,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []row{{ID: "3"}, {ID: "2"}}, result)
+	require.True(t, page.More)
+	require.NotEmpty(t, page.NextCursor)
+
+	// NextCursor must round-trip back to the last surviving row.
+	decoded, err := pgkit.DecodeCursor[rowCursor](page.NextCursor)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+	require.Equal(t, "2", decoded.ID)
+}
+
+func TestCursorPaginatorDefaultsFromNilPage(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), nil, applyIDCursor)
+	require.NoError(t, err)
+
+	sql, _, err := q.ToSql()
+	require.NoError(t, err)
+	// Default page size is 10 → LIMIT 11.
+	require.Equal(t, "SELECT * FROM t LIMIT 11", sql)
+}
+
+func TestCursorPaginatorCapsAtMaxSize(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+		pgkit.WithDefaultSize(5),
+		pgkit.WithMaxSize(10),
+	)
+	page := &pgkit.Page{Size: 999}
+
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	sql, _, err := q.ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT * FROM t LIMIT 11", sql)
+	require.Equal(t, uint32(10), page.Size)
+}
+
+func TestCursorPaginatorMaxSizeBelowDefaultIsLifted(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](
+		pgkit.WithDefaultSize(20),
+		pgkit.WithMaxSize(5),
+	)
+	page := &pgkit.Page{}
+
+	_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	sql, _, err := q.ToSql()
+	require.NoError(t, err)
+	// MaxSize is lifted to DefaultSize, so DefaultSize wins → LIMIT 21.
+	require.Equal(t, "SELECT * FROM t LIMIT 21", sql)
+}
+
+func TestCursorPaginatorWalksPages(t *testing.T) {
+	// End-to-end: paginate a fixed 5-row dataset in pages of 2 and
+	// verify every row surfaces exactly once across three pages.
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(2))
+	all := []row{{ID: "5"}, {ID: "4"}, {ID: "3"}, {ID: "2"}, {ID: "1"}}
+
+	var (
+		page = &pgkit.Page{}
+		seen []row
+	)
+	for step := 0; step < 5; step++ {
+		_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+		require.NoError(t, err)
+
+		fetched := fetch(t, all, q)
+		got, err := paginator.PrepareResult(fetched, page, cursorFromRow)
+		require.NoError(t, err)
+
+		seen = append(seen, got...)
+		if !page.More {
+			break
+		}
+		page.Cursor = page.NextCursor
+		page.NextCursor = ""
+	}
+	require.Equal(t, all, seen)
+	require.False(t, page.More)
+}
+
+func TestCursorPaginatorPrepareResultPropagatesCursorError(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor](pgkit.WithDefaultSize(1))
+	page := &pgkit.Page{}
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+
+	sentinel := errors.New("boom")
+	_, err = paginator.PrepareResult(
+		[]row{{ID: "2"}, {ID: "1"}},
+		page,
+		func(row) (rowCursor, error) { return rowCursor{}, sentinel },
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, sentinel))
+}
+
+func TestCursorPaginatorPanicsOnNilApplyCursor(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
+	require.PanicsWithValue(
+		t,
+		"pgkit: CursorPaginator.PrepareQuery: applyCursor must not be nil",
+		func() { _, _, _ = paginator.PrepareQuery(sq.Select("*").From("t"), &pgkit.Page{}, nil) },
+	)
+}
+
+func TestCursorPaginatorPanicsOnNilCursorFromRow(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor]()
+	page := &pgkit.Page{}
+	_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), page, applyIDCursor)
+	require.NoError(t, err)
+	require.PanicsWithValue(
+		t,
+		"pgkit: CursorPaginator.PrepareResult: cursorFromRow must not be nil",
+		func() { _, _ = paginator.PrepareResult([]row{{ID: "1"}}, page, nil) },
+	)
+}
+
+// In-memory stand-in so the pagination walk exercises encode/decode without a real database.
+func fetch(t *testing.T, all []row, q sq.SelectBuilder) []row {
+	t.Helper()
+	sql, args, err := q.ToSql()
+	require.NoError(t, err)
+
+	limit, err := strconv.Atoi(sql[strings.LastIndex(sql, " ")+1:])
+	require.NoError(t, err)
+
+	cutoff := ""
+	if len(args) == 1 {
+		cutoff = args[0].(string)
+	}
+
+	out := make([]row, 0, limit)
+	for _, r := range all {
+		if cutoff != "" && r.ID >= cutoff {
+			continue
+		}
+		out = append(out, r)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -104,6 +104,31 @@ func TestCursorPaginatorRejectsPreorderedQuery(t *testing.T) {
 	require.ErrorIs(t, err, pgkit.ErrCursorQueryOrdered)
 }
 
+func TestCursorPaginatorRejectsPageOrder(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
+
+	tests := []struct {
+		name string
+		page *pgkit.Page
+	}{
+		{
+			name: "sort",
+			page: &pgkit.Page{Sort: []pgkit.Sort{{Column: "name", Order: pgkit.Asc}}},
+		},
+		{
+			name: "column",
+			page: &pgkit.Page{Column: "name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := paginator.PrepareQuery(sq.Select("*").From("t"), tt.page)
+			require.ErrorIs(t, err, pgkit.ErrCursorPageOrdered)
+		})
+	}
+}
+
 func TestCursorPaginatorInvalidCursor(t *testing.T) {
 	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
 	page := &pgkit.Page{Cursor: "!!!not-base64!!!"}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -104,7 +104,37 @@ func TestCursorPaginatorRejectsPreorderedQuery(t *testing.T) {
 	require.ErrorIs(t, err, pgkit.ErrCursorQueryOrdered)
 }
 
-func TestCursorPaginatorRejectsPageOrder(t *testing.T) {
+func TestCursorPaginatorAllowsMatchingPageOrder(t *testing.T) {
+	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
+
+	tests := []struct {
+		name string
+		page *pgkit.Page
+	}{
+		{
+			name: "sort",
+			page: &pgkit.Page{Sort: []pgkit.Sort{{Column: "id", Order: pgkit.Desc}}},
+		},
+		{
+			name: "column",
+			page: &pgkit.Page{Column: "-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, q, err := paginator.PrepareQuery(sq.Select("*").From("t"), tt.page)
+			require.NoError(t, err)
+
+			sql, args, err := q.ToSql()
+			require.NoError(t, err)
+			require.Equal(t, `SELECT * FROM t ORDER BY "id" DESC LIMIT 11`, sql)
+			require.Empty(t, args)
+		})
+	}
+}
+
+func TestCursorPaginatorRejectsMismatchedPageOrder(t *testing.T) {
 	paginator := pgkit.NewCursorPaginator[row, rowCursor, *rowCursor]()
 
 	tests := []struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/georgysavva/scany/v2 v2.1.4
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.9.0
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/page.go
+++ b/page.go
@@ -1,6 +1,7 @@
 package pgkit
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"slices"
@@ -253,6 +254,18 @@ func (p Paginator[T]) PrepareQuery(q sq.SelectBuilder, page *Page) ([]T, sq.Sele
 	limit := page.Limit()
 	q = q.Limit(limit + 1).Offset(page.Offset()).OrderBy(p.getOrder(page)...)
 	return make([]T, 0, limit+1), q
+}
+
+// Paginate returns offset-paginated rows and the page populated with More.
+func (p Paginator[T]) Paginate(ctx context.Context, query *Querier, q sq.SelectBuilder, page *Page) ([]T, *Page, error) {
+	if page == nil {
+		page = &Page{}
+	}
+	result, q := p.PrepareQuery(q, page)
+	if err := query.GetAll(ctx, q, &result); err != nil {
+		return nil, nil, err
+	}
+	return p.PrepareResult(result, page), page, nil
 }
 
 func (p Paginator[T]) PrepareRaw(q string, args []any, page *Page) ([]T, string, []any) {

--- a/page.go
+++ b/page.go
@@ -81,6 +81,10 @@ type Page struct {
 	More   bool
 	Column string
 	Sort   []Sort
+
+	// Unused by the offset Paginator — shared here so callers can swap paginators without changing the Page type.
+	Cursor     string
+	NextCursor string
 }
 
 func NewPage(size, page uint32, sort ...Sort) *Page {

--- a/table.go
+++ b/table.go
@@ -15,9 +15,14 @@ import (
 // ID is a comparable type used for record IDs.
 type ID comparable
 
+// PtrTo constrains a type parameter to be a pointer to T.
+type PtrTo[T any] interface {
+	*T
+}
+
 // Records must be a pointer with the methods defined on the pointer.
 type Record[T any, I ID] interface {
-	*T // Enforce T is a pointer.
+	PtrTo[T]
 	GetID() I
 	Validate() error
 }

--- a/tests/cursor_test.go
+++ b/tests/cursor_test.go
@@ -25,11 +25,11 @@ func (c *articleCursor) From(article *Article) error {
 	return nil
 }
 
-func TestCursorPaginatorListReturnsPage(t *testing.T) {
+func TestCursorPaginatorPaginateReturnsPage(t *testing.T) {
 	ctx := t.Context()
 	db := initDB(DB)
 
-	account := &Account{Name: "CursorPaginatorList Account"}
+	account := &Account{Name: "CursorPaginatorPaginate Account"}
 	err := db.Accounts.Save(ctx, account)
 	require.NoError(t, err)
 
@@ -48,7 +48,7 @@ func TestCursorPaginatorListReturnsPage(t *testing.T) {
 		From("articles").
 		Where(sq.Eq{"account_id": account.ID})
 
-	first, firstPage, err := paginator.List(ctx, db.Query, q, nil)
+	first, firstPage, err := paginator.Paginate(ctx, db.Query, q, nil)
 	require.NoError(t, err)
 	require.Len(t, first, 2)
 	require.NotNil(t, firstPage)
@@ -59,7 +59,7 @@ func TestCursorPaginatorListReturnsPage(t *testing.T) {
 	page := &pgkit.Page{
 		Cursor: firstPage.NextCursor,
 	}
-	second, secondPage, err := paginator.List(ctx, db.Query, q, page)
+	second, secondPage, err := paginator.Paginate(ctx, db.Query, q, page)
 	require.NoError(t, err)
 	require.Len(t, second, 2)
 	require.Same(t, page, secondPage)
@@ -69,6 +69,51 @@ func TestCursorPaginatorListReturnsPage(t *testing.T) {
 	for _, a := range first {
 		for _, b := range second {
 			require.NotEqual(t, a.ID, b.ID, "cursor pages should not overlap")
+		}
+	}
+}
+
+func TestPaginatorPaginateReturnsPage(t *testing.T) {
+	ctx := t.Context()
+	db := initDB(DB)
+
+	account := &Account{Name: "PaginatorPaginate Account"}
+	err := db.Accounts.Save(ctx, account)
+	require.NoError(t, err)
+
+	for range 5 {
+		err := db.Articles.Save(ctx, &Article{
+			AccountID: account.ID,
+			Author:    "Offset Author",
+		})
+		require.NoError(t, err)
+	}
+
+	paginator := pgkit.NewPaginator[*Article](pgkit.WithDefaultSize(2))
+	q := db.SQL.Select("*").
+		From("articles").
+		Where(sq.Eq{"account_id": account.ID})
+
+	first, firstPage, err := paginator.Paginate(ctx, db.Query, q, nil)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	require.NotNil(t, firstPage)
+	require.Equal(t, uint32(2), firstPage.Size)
+	require.Equal(t, uint32(1), firstPage.Page)
+	require.True(t, firstPage.More)
+
+	page := &pgkit.Page{Page: 2}
+	second, secondPage, err := paginator.Paginate(ctx, db.Query, q, page)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	require.Same(t, page, secondPage)
+	require.Equal(t, uint32(2), secondPage.Size)
+	require.Equal(t, uint32(2), secondPage.Page)
+	require.True(t, secondPage.More)
+
+	for _, a := range first {
+		for _, b := range second {
+			require.NotEqual(t, a.ID, b.ID, "offset pages should not overlap")
 		}
 	}
 }

--- a/tests/cursor_test.go
+++ b/tests/cursor_test.go
@@ -1,0 +1,74 @@
+package pgkit_test
+
+import (
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/goware/pgkit/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type articleCursor struct {
+	ID uint64 `json:"id"`
+}
+
+func (c *articleCursor) Apply(q sq.SelectBuilder) sq.SelectBuilder {
+	return q.Where(sq.Lt{"id": c.ID})
+}
+
+func (c *articleCursor) OrderBy() []pgkit.Sort {
+	return []pgkit.Sort{{Column: "id", Order: pgkit.Desc}}
+}
+
+func (c *articleCursor) From(article *Article) error {
+	c.ID = article.ID
+	return nil
+}
+
+func TestCursorPaginatorListReturnsPage(t *testing.T) {
+	ctx := t.Context()
+	db := initDB(DB)
+
+	account := &Account{Name: "CursorPaginatorList Account"}
+	err := db.Accounts.Save(ctx, account)
+	require.NoError(t, err)
+
+	for range 5 {
+		err := db.Articles.Save(ctx, &Article{
+			AccountID: account.ID,
+			Author:    "Cursor Author",
+		})
+		require.NoError(t, err)
+	}
+
+	paginator := pgkit.NewCursorPaginator[*Article, articleCursor, *articleCursor](
+		pgkit.WithDefaultSize(2),
+	)
+	q := db.SQL.Select("*").
+		From("articles").
+		Where(sq.Eq{"account_id": account.ID})
+
+	first, firstPage, err := paginator.List(ctx, db.Query, q, nil)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	require.NotNil(t, firstPage)
+	require.Equal(t, uint32(2), firstPage.Size)
+	require.True(t, firstPage.More)
+	require.NotEmpty(t, firstPage.NextCursor)
+
+	page := &pgkit.Page{
+		Cursor: firstPage.NextCursor,
+	}
+	second, secondPage, err := paginator.List(ctx, db.Query, q, page)
+	require.NoError(t, err)
+	require.Len(t, second, 2)
+	require.Same(t, page, secondPage)
+	require.True(t, secondPage.More)
+	require.NotEmpty(t, secondPage.NextCursor)
+
+	for _, a := range first {
+		for _, b := range second {
+			require.NotEqual(t, a.ID, b.ID, "cursor pages should not overlap")
+		}
+	}
+}


### PR DESCRIPTION
Keyset / cursor pagination as a sibling to the existing offset `Paginator[T]`. Came up while reviewing a downstream impl ([0xPolygon/omsx#1233](https://github.com/0xPolygon/omsx/pull/1233)) that re-implemented the same encode/decode + LIMIT n+1 pattern locally — the primitives are generic enough to live in pgkit and the lifecycle fits the existing `PrepareQuery` / `PrepareResult` shape exactly.

Offset pagination is fine for stable, small result sets, but on append-only / time-ordered tables under concurrent writes it visibly skips or duplicates rows as new ones land between page fetches. Keyset (cursor) pagination uses the last row of the previous page as a `WHERE` predicate, so newly-inserted rows don't shift the next page.

---

## What's added

**`cursor.go`** — three pieces:

- `EncodeCursor[C any](C) (string, error)` / `DecodeCursor[C any](string) (*C, error)` — opaque, URL-safe base64+JSON. Empty input → `(nil, nil)` so callers compose with a nil-check. Malformed → `ErrInvalidCursor` so callers can map to 400, not 500.
- `CursorPaginator[T any, C any]` — sibling of `Paginator[T]`, same lifecycle:
  ```go
  rows, q, err := paginator.PrepareQuery(query, page, applyCursor)
  if err := db.GetAll(ctx, q, &rows); err \!= nil { ... }
  rows, err = paginator.PrepareResult(rows, page, cursorFromRow)
  ```
- Two type parameters (`T` row, `C` cursor) so the WHERE clause and serialized cursor are both typed.

**`page.go`** — `Page` gains `Cursor` and `NextCursor` (both `string`). Unused by the offset paginator; shared on the type so callers can swap paginators without changing the request shape.

## Design choices

| Choice | Rationale |
|---|---|
| Two type parameters (`T`, `C`) | Lets `applyCursor` get a typed cursor argument instead of `any` smuggling. |
| Caller owns `ORDER BY` | The cursor `WHERE` is order-dependent — only the caller knows which columns to compare. Mismatched ORDER BY and applyCursor silently skips or duplicates rows (documented). |
| Reuse `PaginatorSettings` / `WithDefaultSize` / `WithMaxSize` | Same options as offset — `WithSort` / `WithColumnFunc` are no-ops here because the caller owns ORDER BY. |
| Extend the existing `Page`, no parallel type | Field discipline by mode (offset vs cursor) mirrors how `Column` / `Sort` already coexist on `Page` without enforcement. |
| `nil applyCursor` / `cursorFromRow` panic at function entry | Surfaces misconfiguration on the *first* request rather than the second (when a cursor first appears or `more` first fires). |
| Unsigned cursor | pgkit has no tenant model. Documented that callers must re-apply scope from the request, never from the cursor. An `HMACCursor` variant can be added later if needed. |

## Tests

Pure-unit, no DB needed thanks to the PrepareQuery/PrepareResult split. Coverage:

- Encode/decode round-trip, empty input, invalid base64, invalid JSON
- First page (no cursor) chains `LIMIT n+1`, capacity-correct pre-allocated slice
- With cursor: `applyCursor` invoked, WHERE clause appended
- Invalid cursor → `ErrInvalidCursor` propagated through `PrepareQuery`
- `PrepareResult` no-more case (no `NextCursor`, `More=false`)
- `PrepareResult` has-more case (trims to limit, `NextCursor` round-trips back to last surviving row)
- Default size from nil page, caps at max, max-below-default is lifted
- End-to-end walk of a 5-row dataset across 3 pages, every row surfaces exactly once
- `PrepareResult` propagates `cursorFromRow` errors
- nil-callback panics on both `PrepareQuery` and `PrepareResult`

```
go test -run 'TestEncodeDecode|TestDecodeCursor|TestCursorPaginator' ./...
ok  	github.com/goware/pgkit/v2	1.157s
```

Existing `TestPagination*` tests unaffected.

## Not in this PR (intentionally)

- **No `Table.ListCursor`** convenience. The PrepareQuery/PrepareResult split is enough; a table-level wrapper can come later if usage warrants it.
- **No cursor signing.** Easy to add (`WithCursorSigner(...)`) once a caller needs it. Skipped to keep v1 minimal.

Happy to split this into smaller commits, rename, or restructure if the shape isn't what you'd prefer.
